### PR TITLE
Add linking of spec sentences to compiler tests

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -11,6 +11,8 @@ gpp -H index.md | pandoc --filter ../scripts/ProcessTODOFilter.kts \
                          -H preamble.md -s -f markdown-raw_html+smart+tex_math_double_backslash \
                          -o ../.pages/index.html
 cp index.css ../.pages/
+cp index.js ../.pages/
+cp tests-map.json ../.pages/
 echo "done"
 
 echo "Rendering PDF..."

--- a/src/index.css
+++ b/src/index.css
@@ -346,3 +346,120 @@ span.TODO-marker {
     page-break-after: avoid;
   }
 }
+
+body.tests-linking {
+  padding: 0 30px;
+}
+
+body.tests-linking .paragraph,
+body.tests-linking > dl,
+body.tests-linking > ul,
+body.tests-linking > ol {
+  border: 3px solid rgb(255, 195, 195);
+  border-radius: 7px;
+  padding: 10px 30px;
+  box-sizing: border-box;
+  width: calc(100% + 26px);
+  margin-left: -33px;
+  margin-top: 20px;
+  position: relative;
+}
+
+body.tests-linking .sentence {
+  position: relative;
+  padding: 0 5px;
+  border-right: 3px solid rgba(255, 0, 0, .5);
+  border-left: 3px solid rgba(255, 0, 0, .5);
+  margin-right: 5px;
+  background: rgb(255, 195, 195);
+  border-radius: 5px;
+}
+
+body.tests-linking .sentence.covered {
+  background: rgb(213, 236, 206);
+}
+
+body.tests-linking .test-links {
+  text-transform: uppercase;
+  right: 5px;
+  top: -22px;
+  font-size: 13px;
+  position: absolute;
+}
+
+body.tests-linking .test-links a {
+  margin-left: 5px;
+}
+
+body.tests-linking .unexpected-behaviour-marker {
+  color: red;
+  position: absolute;
+  left: -30px;
+  width: 16px;
+  height: 16px;
+  background: red;
+  border-radius: 8px;
+  margin-top: 5px;
+}
+
+body.tests-linking .sentence.unexpected-behaviour .number-info:before {
+  content: "!!! ";
+  color: red;
+}
+
+body.tests-linking .sentence .coverage-info {
+  visibility: hidden;
+  width: 350px;
+  background-color: #555;
+  color: #fff;
+  border-radius: 6px;
+  padding: 5px 10px;
+  position: absolute;
+  z-index: 1;
+  bottom: 125%;
+  left: 50%;
+  margin-left: -175px;
+  opacity: 0;
+  transition: opacity 0.3s;
+  font-size: 12px;
+  font-family: 'Arial', sans-serif;
+  font-weight: bold;
+}
+
+body.tests-linking .sentence .coverage-info::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: #555 transparent transparent transparent;
+}
+
+body.tests-linking .sentence:hover .coverage-info {
+  visibility: visible;
+  opacity: 1;
+}
+
+body.tests-linking .sentence > .number-info {
+  font-weight: bold;
+  border-right: 3px solid rgba(255, 0, 0, .5);
+  padding: 0 6px 0 3px;
+  margin-right: 5px;
+  line-height: 18px;
+  display: inline-block;
+}
+
+body.tests-linking .paragraph > .number-info,
+body.tests-linking > dl > .number-info,
+body.tests-linking > ul > .number-info,
+body.tests-linking > ol > .number-info {
+  position: absolute;
+  margin-top: -27px;
+  margin-left: -27px;
+  background: #fff;
+  padding: 0 10px;
+  border-radius: 20px;
+  border: 1px solid #969696;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,205 @@
+var testInfoMapPath = "./tests-map.json";
+var githubTestsLink = "https://github.com/JetBrains/kotlin/tree/master/";
+
+var testAreas = ["diagnostics", "psi", "codegen"];
+var paragraphSelector = [".paragraph", "DL", "UL", "OL"].join(",");
+
+// temporary helper sections name-number map
+var sectionsMap = {
+    "when-expression": "16.30"
+};
+
+function getQueryParam(name, url) {
+    if (!url) url = window.location.href;
+    name = name.replace(/[\[\]]/g, "\\$&");
+    var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+        results = regex.exec(url);
+    if (!results) return null;
+    if (!results[2]) return '';
+    return decodeURIComponent(results[2].replace(/\+/g, " "));
+}
+
+function loadJSON(url, callback) {
+    var request = new XMLHttpRequest();
+    request.overrideMimeType("application/json");
+    request.open("GET", url, true);
+    request.onreadystatechange = function () {
+        if (request.readyState === 4 && request.status === 200) {
+            callback(JSON.parse(request.responseText));
+        }
+    };
+    request.send(null);
+}
+
+function highlightSentence(hashComponents) {
+    var section = hashComponents[0];
+    var paragraph = hashComponents[1];
+    var sentence = hashComponents[2];
+
+    var sectionElement = document.querySelector(section);
+    var nextSibling = sectionElement.nextElementSibling;
+    var counter = 1;
+
+    while (nextSibling) {
+        if (nextSibling.matches(paragraphSelector) && counter++ == paragraph) {
+            nextSibling.scrollIntoView();
+            var sentenceElement = nextSibling.getElementsByClassName('sentence')[sentence - 1];
+            sentenceElement.style.backgroundColor = 'yellow';
+            break;
+        }
+        nextSibling = nextSibling.nextElementSibling;
+    }
+}
+
+function insertNumberInfo(element, elementNumber) {
+    var numberInfoSpan = document.createElement("span");
+    numberInfoSpan.setAttribute("class", "number-info");
+    numberInfoSpan.innerHTML = elementNumber;
+    element.insertBefore(numberInfoSpan, element.firstChild);
+}
+
+function createTestLinkElement(testArea, paragraphNumber, sectionId) {
+    var numberInfoSpan = document.createElement("a");
+    numberInfoSpan.innerHTML = testArea;
+    numberInfoSpan.setAttribute("target", "_blank");
+    numberInfoSpan.setAttribute("href", githubTestsLink + "compiler/tests-spec/testData/" + testArea + "/s-" + sectionsMap[sectionId] + "_" + sectionId + "/p-" + paragraphNumber);
+    return numberInfoSpan
+}
+
+function insertLinksToGithub(paragraph, paragraphNumber, paragraphObject, sectionId) {
+    var testTypesPresented = {};
+    testAreas.forEach(function (testArea) {
+        Object.keys(paragraphObject).forEach(function (sentenceNumber) {
+            if (testArea in paragraphObject[sentenceNumber]) {
+                testTypesPresented[testArea] = true;
+            }
+        });
+    });
+
+    if (Object.keys(testTypesPresented).length !== 0) {
+        var numberInfoSpan = document.createElement("span");
+        numberInfoSpan.setAttribute("class", "test-links");
+        testAreas.forEach(function (testArea) {
+            if (testTypesPresented[testArea]) {
+                numberInfoSpan.prepend(createTestLinkElement(testArea, paragraphNumber, sectionId))
+            }
+        });
+
+        numberInfoSpan.prepend("Tests: ");
+
+        paragraph.insertBefore(numberInfoSpan, paragraph.firstChild);
+    }
+}
+
+function detectUnexpectedBehaviour(testsOfType) {
+    var unexpectedBehaviour = false;
+    Object.keys(testsOfType).forEach(function (testNumber) {
+        if (testsOfType[testNumber].unexpectedBehaviour) {
+            unexpectedBehaviour = true;
+        }
+        var testCases = testsOfType[testNumber].cases;
+        if (testCases) {
+            testCases.forEach(function (testCase) {
+                if (testCase.unexpectedBehaviour) {
+                    unexpectedBehaviour = true;
+                }
+            });
+        }
+    });
+
+    return unexpectedBehaviour;
+}
+
+function showSentenceCoverage(sentenceElement, sentenceTestInfo) {
+    var testTypes = {"pos": "positive", "neg": "negative"};
+
+    sentenceElement.classList.add("covered");
+
+    var testsByArea = [];
+    var unexpectedBehaviour = false;
+
+    Object.keys(sentenceTestInfo).forEach(function (testArea) {
+        var testNumberByType = {};
+        var testsOfArea = sentenceTestInfo[testArea];
+        Object.keys(testsOfArea).forEach(function (testType) {
+            testNumberByType[testType] = Object.keys(testsOfArea[testType]).length;
+            unexpectedBehaviour |= detectUnexpectedBehaviour(testsOfArea[testType]);
+        });
+
+        var testNumberByTypeInfo = [];
+        Object.keys(testNumberByType).forEach(function (testNumberInfo) {
+            testNumberByTypeInfo.push(testNumberByType[testNumberInfo] + " " + testTypes[testNumberInfo]);
+        });
+        if (testNumberByTypeInfo.length > 0) {
+            testsByArea.push("<b>" + testArea.toLocaleUpperCase() + "</b>: " + testNumberByTypeInfo.join(", "));
+        }
+    });
+
+    var coverageInfoSpan = document.createElement("span");
+    coverageInfoSpan.classList.add("coverage-info");
+    if (unexpectedBehaviour) {
+        var unexpectedBehaviourSpan = document.createElement("span");
+        unexpectedBehaviourSpan.classList.add("unexpected-behaviour-marker");
+        sentenceElement.parentNode.insertBefore(unexpectedBehaviourSpan, sentenceElement);
+        sentenceElement.classList.add("unexpected-behaviour")
+    }
+    coverageInfoSpan.innerHTML = testsByArea.join("<br />");
+    sentenceElement.prepend(coverageInfoSpan);
+}
+
+function showParagraphCoverage(paragraph, paragraphs, paragraphCounter, sectionId) {
+    var sentenceElements = paragraph.querySelectorAll(".sentence");
+    var paragraphObject = paragraphs ? paragraphs[paragraphCounter] : null;
+    var sentenceCounter = 1;
+
+    Array.from(sentenceElements).forEach(function(sentenceElement) {
+        if (paragraphObject && sentenceCounter in paragraphObject)
+            showSentenceCoverage(sentenceElement, paragraphObject[sentenceCounter], paragraph);
+        insertNumberInfo(sentenceElement, sentenceCounter);
+        sentenceCounter++;
+    });
+    insertNumberInfo(paragraph, paragraphCounter);
+    if (paragraphObject != null)
+        insertLinksToGithub(paragraph, paragraphCounter, paragraphObject, sectionId);
+}
+
+function showCoverage(specTestsMap) {
+    var newSectionTags = ["H1", "H2", "H3"];
+    var sections = document.querySelectorAll(newSectionTags.join(","));
+
+    Array.from(sections).forEach(function(sectionElement) {
+        var nextSibling = sectionElement.nextElementSibling;
+        var sectionIdObject = sectionElement.attributes.getNamedItem("id");
+
+        if (!sectionIdObject)
+            return;
+
+        var sectionId = sectionIdObject.value;
+        var paragraphs = specTestsMap[sectionId];
+        var paragraphCounter = 1;
+
+        while (nextSibling) {
+            if (newSectionTags.indexOf(nextSibling.tagName) !== -1)
+                break;
+
+            var isParagraph = nextSibling.matches(paragraphSelector);
+            var childParagraph = nextSibling.querySelector(".paragraph");
+
+            if (isParagraph || childParagraph) {
+                showParagraphCoverage(childParagraph || nextSibling, paragraphs, paragraphCounter, sectionId);
+                paragraphCounter++;
+            }
+            nextSibling = nextSibling.nextElementSibling;
+        }
+    })
+}
+
+window.addEventListener("DOMContentLoaded", function() {
+    if (location.hash)
+        highlightSentence(location.hash.split(':'));
+
+    if (getQueryParam("mode") === "tests_linking") {
+        loadJSON(testInfoMapPath, showCoverage);
+        document.body.classList.add("tests-linking");
+    }
+});

--- a/src/preamble.md
+++ b/src/preamble.md
@@ -1,0 +1,1 @@
+<script src="index.js"></script>

--- a/src/tests-map.json
+++ b/src/tests-map.json
@@ -1,0 +1,1374 @@
+{
+  "when-expression": {
+    "1": {
+      "3": {
+        "diagnostics": {
+          "pos": {
+            "1": {
+              "description": "Empty 'when' with bound value."
+            },
+            "2": {
+              "description": "Empty 'when' without bound value."
+            }
+          }
+        }
+      }
+    },
+    "2": {
+      "1": {
+        "diagnostics": {
+          "neg": {
+            "1": {
+              "cases": [
+                {
+                  "description": "'When' with break expression (without label)."
+                },
+                {
+                  "description": "'When' with continue expression (without label)."
+                }
+              ],
+              "description": "'When' without bound value and not allowed break and continue expression (without labels) in the control structure body."
+            }
+          },
+          "pos": {
+            "1": {
+              "cases": [
+                {
+                  "description": "'When' as expression with control structure body as if expression (must be exhaustive)."
+                },
+                {
+                  "description": "'When' as expression with control structure body as when expression (must be exhaustive)."
+                },
+                {
+                  "description": "'When' with control structure body as arithmetic expressions."
+                },
+                {
+                  "description": "'When' with control structure body as boolean expressions (logical, equality and comparison)."
+                },
+                {
+                  "description": "'When' with control structure body as break expression."
+                },
+                {
+                  "description": "'When' with control structure body as call expression."
+                },
+                {
+                  "description": "'When' with control structure body as cast expression."
+                },
+                {
+                  "description": "'When' with control structure body as concatenations."
+                },
+                {
+                  "description": "'When' with control structure body as continue expression."
+                },
+                {
+                  "description": "'When' with control structure body as elvis operator expression."
+                },
+                {
+                  "description": "'When' with control structure body as fun literal."
+                },
+                {
+                  "description": "'When' with control structure body as if expression."
+                },
+                {
+                  "description": "'When' with control structure body as indexing expression."
+                },
+                {
+                  "description": "'When' with control structure body as lambda literal."
+                },
+                {
+                  "description": "'When' with control structure body as literals."
+                },
+                {
+                  "description": "'When' with control structure body as object literal."
+                },
+                {
+                  "description": "'When' with control structure body as postfix operator expression."
+                },
+                {
+                  "description": "'When' with control structure body as prefix operator expression."
+                },
+                {
+                  "description": "'When' with control structure body as property access expression."
+                },
+                {
+                  "description": "'When' with control structure body as range expression."
+                },
+                {
+                  "description": "'When' with control structure body as return expression."
+                },
+                {
+                  "description": "'When' with control structure body as this expression."
+                },
+                {
+                  "description": "'When' with control structure body as throw expression."
+                },
+                {
+                  "description": "'When' with control structure body as try expression."
+                },
+                {
+                  "description": "'When' with control structure body as when expression."
+                }
+              ],
+              "description": "'When' without bound value and with different variants of expressions in the control structure body."
+            }
+          }
+        }
+      },
+      "2": {
+        "diagnostics": {
+          "neg": {
+            "1": {
+              "description": "'When' without bound value and with not boolean condition in 'when condition'."
+            },
+            "2": {
+              "description": "'When' without bound value and not allowed comma in when entry."
+            }
+          },
+          "pos": {
+            "1": {
+              "cases": [
+                {
+                  "description": "'When' with boolean constants."
+                },
+                {
+                  "description": "'When' with boolean expressions and else branch."
+                },
+                {
+                  "description": "'When' with boolean expressions."
+                },
+                {
+                  "description": "'When' with boolean expressions."
+                },
+                {
+                  "description": "'When' with boolean literals."
+                },
+                {
+                  "description": "'When' with containment operator."
+                },
+                {
+                  "description": "'When' with invert type checking operator."
+                },
+                {
+                  "description": "'When' with type checking operator by sealed class."
+                },
+                {
+                  "description": "'When' with type checking operator."
+                }
+              ],
+              "description": "'When' without bound value and different variants of the boolean conditions (logical, equality, comparison, type checking operator, containment operator)."
+            },
+            "2": {
+              "cases": [
+                {
+                  "description": "'When' as expression with only one 'else' branch."
+                },
+                {
+                  "description": "'When' as statement with only one 'else' branch."
+                }
+              ],
+              "description": "'When' without bound value and only one 'else' branch."
+            },
+            "3": {
+              "cases": [
+                {
+                  "description": "'When' with break expression in condition."
+                },
+                {
+                  "description": "'When' with continue expression in condition."
+                },
+                {
+                  "description": "'When' with mixed Nothing expression in condition."
+                },
+                {
+                  "description": "'When' with return expression in condition."
+                },
+                {
+                  "description": "'When' with throw expression in condition."
+                },
+                {
+                  "description": "'When' with values of Nothing type."
+                }
+              ],
+              "description": "'When' without bound value and with Nothing in condition (subtype of Boolean).",
+              "issues": [
+                "KT-25948"
+              ],
+              "unexpectedBehaviour": true
+            }
+          }
+        }
+      }
+    },
+    "4": {
+      "1": {
+        "diagnostics": {
+          "neg": {
+            "1": {
+              "cases": [
+                {
+                  "description": "'When' with 'else' branch in the first position."
+                },
+                {
+                  "description": "'When' with 'else' branch in the middle position."
+                },
+                {
+                  "description": "'When' with two 'else' branches."
+                }
+              ],
+              "description": "'When' without bound value and with 'else' branch not in the last position."
+            }
+          },
+          "pos": {
+            "1": {
+              "cases": [
+                {
+                  "description": "'When' with else branch as expression"
+                },
+                {
+                  "description": "'When' with else branch as statement"
+                }
+              ],
+              "description": "'When' without bound value and with else branch in the last position."
+            }
+          }
+        }
+      }
+    },
+    "5": {
+      "1": {
+        "diagnostics": {
+          "neg": {
+            "1": {
+              "cases": [
+                {
+                  "description": "'When' with break expression (without label)."
+                },
+                {
+                  "description": "'When' with continue expression (without label)."
+                }
+              ],
+              "description": "'When' with bound value and not allowed break and continue expression (without labels) in the control structure body."
+            }
+          },
+          "pos": {
+            "1": {
+              "cases": [
+                {
+                  "description": "'When' as expression with control structure body as if expression (must be exhaustive)."
+                },
+                {
+                  "description": "'When' as expression with control structure body as when expression (must be exhaustive)."
+                },
+                {
+                  "description": "'When' with control structure body as arithmetic expressions."
+                },
+                {
+                  "description": "'When' with control structure body as boolean expressions (logical, equality and comparison)."
+                },
+                {
+                  "description": "'When' with control structure body as break expression."
+                },
+                {
+                  "description": "'When' with control structure body as call expression."
+                },
+                {
+                  "description": "'When' with control structure body as cast expression."
+                },
+                {
+                  "description": "'When' with control structure body as concatenations."
+                },
+                {
+                  "description": "'When' with control structure body as continue expression."
+                },
+                {
+                  "description": "'When' with control structure body as elvis operator expression."
+                },
+                {
+                  "description": "'When' with control structure body as fun literal."
+                },
+                {
+                  "description": "'When' with control structure body as if expression."
+                },
+                {
+                  "description": "'When' with control structure body as indexing expression."
+                },
+                {
+                  "description": "'When' with control structure body as lambda literal."
+                },
+                {
+                  "description": "'When' with control structure body as literals."
+                },
+                {
+                  "description": "'When' with control structure body as object literal."
+                },
+                {
+                  "description": "'When' with control structure body as postfix operator expression."
+                },
+                {
+                  "description": "'When' with control structure body as prefix operator expression."
+                },
+                {
+                  "description": "'When' with control structure body as property access expression."
+                },
+                {
+                  "description": "'When' with control structure body as range expression."
+                },
+                {
+                  "description": "'When' with control structure body as return expression."
+                },
+                {
+                  "description": "'When' with control structure body as this expression."
+                },
+                {
+                  "description": "'When' with control structure body as throw expression."
+                },
+                {
+                  "description": "'When' with control structure body as try expression."
+                },
+                {
+                  "description": "'When' with control structure body as when expression."
+                }
+              ],
+              "description": "'When' with bound value and with different variants of expressions in the control structure body."
+            }
+          }
+        }
+      }
+    },
+    "6": {
+      "1": {
+        "diagnostics": {
+          "neg": {
+            "1": {
+              "cases": [
+                {
+                  "description": "'When' with Any type test condition."
+                },
+                {
+                  "description": "'When' with Nothing type test condition."
+                },
+                {
+                  "description": "'When' with custom class type test condition."
+                }
+              ],
+              "description": "'When' with bound value and type test condition (without companion object in classes), but without type checking operator."
+            },
+            "2": {
+              "description": "'When' with bound value and type test condition on the non-type operand of the type checking operator."
+            }
+          },
+          "pos": {
+            "1": {
+              "cases": [
+                {
+                  "description": "'When' with 'else' branch and type test condition on Any."
+                },
+                {
+                  "description": "'When' with 'else' branch and type test condition on nullable (redundant) Any."
+                },
+                {
+                  "description": "'When' with 'else' branch and type test condition on the various nullable basic types (two nullable type check).",
+                  "issues": [
+                    "KT-22996"
+                  ],
+                  "unexpectedBehaviour": true
+                },
+                {
+                  "description": "'When' with type test condition on the objetcs."
+                },
+                {
+                  "description": "'When' with type test condition on the various basic types."
+                },
+                {
+                  "description": "'When' with type test condition on the various nullable basic types."
+                }
+              ],
+              "description": "'When' with bound value and type test condition."
+            },
+            "2": {
+              "cases": [
+                {
+                  "description": "'When' in which all branches includes invert type checking operators."
+                },
+                {
+                  "description": "'When' with direct and invert (with null-check) type checking operators on the same types and redundant null-check.",
+                  "issues": [
+                    "KT-22996"
+                  ],
+                  "unexpectedBehaviour": true
+                },
+                {
+                  "description": "'When' with direct and invert (with null-check) type checking operators on the same types.",
+                  "issues": [
+                    "KT-22996"
+                  ],
+                  "unexpectedBehaviour": true
+                },
+                {
+                  "description": "'When' with direct and invert type checking operator on the objects."
+                },
+                {
+                  "description": "'When' with direct and invert type checking operators on the same types and null-check."
+                }
+              ],
+              "description": "'When' with bound value and type test condition (invert type checking operator)."
+            },
+            "3": {
+              "cases": [
+                {
+                  "description": "'When' with 'else' branch and type test condition on the various nullable basic types (two different nullable type check in the one branch).",
+                  "issues": [
+                    "KT-22996"
+                  ],
+                  "unexpectedBehaviour": true
+                },
+                {
+                  "description": "'When' with 'else' branch and type test condition on the various nullable basic types (two nullable type check in the different branches).",
+                  "issues": [
+                    "KT-22996"
+                  ],
+                  "unexpectedBehaviour": true
+                },
+                {
+                  "description": "'When' with 'else' branch and type test condition on the various nullable basic types (two nullable type check in the one branch).",
+                  "issues": [
+                    "KT-22996"
+                  ],
+                  "unexpectedBehaviour": true
+                },
+                {
+                  "description": "'When' with 'else' branch and type test condition on the various nullable basic types (two nullable type check).",
+                  "issues": [
+                    "KT-22996"
+                  ],
+                  "unexpectedBehaviour": true
+                },
+                {
+                  "description": "'When' with 'else' branch and type test condition on the various nullable basic types."
+                },
+                {
+                  "description": "'When' with type test condition on the various basic types."
+                }
+              ],
+              "description": "'When' with bound value and enumaration of type test conditions."
+            },
+            "4": {
+              "cases": [
+                {
+                  "description": "'When' with direct (first) and invert (second) type checking operator on the some type in the one branch."
+                },
+                {
+                  "description": "'When' with direct (second) and invert (first) type checking operator in the one branch."
+                },
+                {
+                  "description": "'When' with direct and invert (nullable) type checking operator on the some type in the one branch."
+                },
+                {
+                  "description": "'When' with direct and invert type checking operator and null-check in the one branch.",
+                  "issues": [
+                    "KT-22996"
+                  ],
+                  "unexpectedBehaviour": true
+                },
+                {
+                  "description": "'When' with direct and invert type checking operator in the one branch and other branch and double nullable type check.",
+                  "issues": [
+                    "KT-22996"
+                  ],
+                  "unexpectedBehaviour": true
+                },
+                {
+                  "description": "'When' with direct and invert type checking operator in the one branch and other branch."
+                },
+                {
+                  "description": "'When' with three invert type checking operator in the one branch."
+                }
+              ],
+              "description": "'When' with bound value and enumaration of type test conditions (with invert type checking operator)."
+            }
+          }
+        }
+      },
+      "3": {
+        "diagnostics": {
+          "neg": {
+            "1": {
+              "description": "'When' with bound value and 'when condition' with range expression, but without containment checking operator."
+            },
+            "2": {
+              "cases": [
+                {
+                  "description": "'When' with values of Nothing (all existing contains operators used here).",
+                  "issues": [
+                    "KT-25948"
+                  ],
+                  "unexpectedBehaviour": true
+                },
+                {
+                  "description": "'When' with values of types without defined contains operator."
+                }
+              ],
+              "description": "'When' with bound value and 'when condition' with contains operator and type without defined contains operator."
+            }
+          },
+          "pos": {
+            "1": {
+              "cases": [
+                {
+                  "description": "'When' on types with contains method defined."
+                },
+                {
+                  "description": "'When' with range operator."
+                }
+              ],
+              "description": "'When' with bound value and containment operator."
+            },
+            "2": {
+              "cases": [
+                {
+                  "description": "'When' on types with contains method defined."
+                },
+                {
+                  "description": "'When' with range operator."
+                }
+              ],
+              "description": "'When' with bound value and enumeration of the containment operators."
+            }
+          }
+        }
+      },
+      "5": {
+        "diagnostics": {
+          "neg": {
+            "1": {
+              "cases": [
+                {
+                  "description": "'When' with assignments in when condition."
+                },
+                {
+                  "description": "'When' with cycles in when condition."
+                }
+              ],
+              "description": "'When' with bound value and non-expressions in 'when condition'."
+            },
+            "2": {
+              "cases": [
+                {
+                  "description": "'When' with break expression (without label)."
+                },
+                {
+                  "description": "'When' with continue expression (without label)."
+                }
+              ],
+              "description": "'When' with bound value and not allowed break and continue expression (without labels) in 'when condition'."
+            }
+          },
+          "pos": {
+            "1": {
+              "cases": [
+                {
+                  "description": "'When' with condition as arithmetic expressions."
+                },
+                {
+                  "description": "'When' with condition as boolean expressions (logical, equality and comparison)."
+                },
+                {
+                  "description": "'When' with condition as break expression."
+                },
+                {
+                  "description": "'When' with condition as call expression."
+                },
+                {
+                  "description": "'When' with condition as cast expression."
+                },
+                {
+                  "description": "'When' with condition as concatenations."
+                },
+                {
+                  "description": "'When' with condition as continue expression."
+                },
+                {
+                  "description": "'When' with condition as elvis operator expression."
+                },
+                {
+                  "description": "'When' with condition as fun literal."
+                },
+                {
+                  "description": "'When' with condition as if expression."
+                },
+                {
+                  "description": "'When' with condition as indexing expression."
+                },
+                {
+                  "description": "'When' with condition as lambda literal."
+                },
+                {
+                  "description": "'When' with condition as literals."
+                },
+                {
+                  "description": "'When' with condition as object literal."
+                },
+                {
+                  "description": "'When' with condition as postfix operator expression."
+                },
+                {
+                  "description": "'When' with condition as prefix operator expression."
+                },
+                {
+                  "description": "'When' with condition as property access expression."
+                },
+                {
+                  "description": "'When' with condition as range expression."
+                },
+                {
+                  "description": "'When' with condition as return expression."
+                },
+                {
+                  "description": "'When' with condition as this expression."
+                },
+                {
+                  "description": "'When' with condition as throw expression."
+                },
+                {
+                  "description": "'When' with condition as try expression."
+                },
+                {
+                  "description": "'When' with condition as when expression."
+                }
+              ],
+              "description": "'When' with enumeration of the different variants of expressions in 'when condition'."
+            },
+            "2": {
+              "cases": [
+                {
+                  "description": "'When' with condition as arithmetic expressions."
+                },
+                {
+                  "description": "'When' with condition as boolean expressions (logical, equality and comparison)."
+                },
+                {
+                  "description": "'When' with condition as break expression."
+                },
+                {
+                  "description": "'When' with condition as call expression."
+                },
+                {
+                  "description": "'When' with condition as cast expression."
+                },
+                {
+                  "description": "'When' with condition as concatenations."
+                },
+                {
+                  "description": "'When' with condition as continue expression."
+                },
+                {
+                  "description": "'When' with condition as elvis operator expression."
+                },
+                {
+                  "description": "'When' with condition as fun literal."
+                },
+                {
+                  "description": "'When' with condition as if expression."
+                },
+                {
+                  "description": "'When' with condition as indexing expression."
+                },
+                {
+                  "description": "'When' with condition as lambda literal."
+                },
+                {
+                  "description": "'When' with condition as literals."
+                },
+                {
+                  "description": "'When' with condition as mixed Nothing expressions."
+                },
+                {
+                  "description": "'When' with condition as mixed Nothing expressions."
+                },
+                {
+                  "description": "'When' with condition as object literal."
+                },
+                {
+                  "description": "'When' with condition as postfix operator expression."
+                },
+                {
+                  "description": "'When' with condition as prefix operator expression."
+                },
+                {
+                  "description": "'When' with condition as property access expression."
+                },
+                {
+                  "description": "'When' with condition as range expression."
+                },
+                {
+                  "description": "'When' with condition as return expression."
+                },
+                {
+                  "description": "'When' with condition as this expression."
+                },
+                {
+                  "description": "'When' with condition as throw expression."
+                },
+                {
+                  "description": "'When' with condition as try expression."
+                },
+                {
+                  "description": "'When' with condition as when expression."
+                },
+                {
+                  "description": "'When' with two labels in condition: with const value and nullable const value.",
+                  "issues": [
+                    "KT-26045"
+                  ],
+                  "unexpectedBehaviour": true
+                }
+              ],
+              "description": "'When' with different variants of the arithmetic expressions (additive expression and multiplicative expression) in 'when condition'."
+            }
+          }
+        }
+      },
+      "7": {
+        "diagnostics": {
+          "neg": {
+            "1": {
+              "cases": [
+                {
+                  "description": "'When' with 'else' branch in the first position."
+                },
+                {
+                  "description": "'When' with 'else' branch in the middle position."
+                },
+                {
+                  "description": "'When' with two 'else' branches."
+                }
+              ],
+              "description": "'When' with bound value and with else branch not in the last position."
+            }
+          },
+          "pos": {
+            "1": {
+              "cases": [
+                {
+                  "description": "Simple when with bound value, with 'else' branch and expression as when condition."
+                },
+                {
+                  "description": "Simple when with bound value, with 'else' branch and range test as when condition."
+                },
+                {
+                  "description": "Simple when with bound value, with 'else' branch and type test as when condition."
+                }
+              ],
+              "description": "'When' with bound value and else branch."
+            }
+          }
+        }
+      }
+    },
+    "9": {
+      "1": {
+        "diagnostics": {
+          "neg": {
+            "1": {
+              "cases": [
+                {
+                  "description": "Checking all types except the Any (implicit cast to any) in 'when' with bound value."
+                },
+                {
+                  "description": "Checking all types except the Any (implicit cast to any) in 'when' without bound value."
+                },
+                {
+                  "description": "Checking all types except the correct one (custom types) in 'when' with bound value."
+                },
+                {
+                  "description": "Checking all types except the correct one (custom types) in 'when' without bound value."
+                },
+                {
+                  "description": "Checking all types except the correct one (numbers) in 'when' with bound value.",
+                  "issues": [
+                    "KT-25268"
+                  ],
+                  "unexpectedBehaviour": true
+                },
+                {
+                  "description": "Checking all types except the correct one (numbers) in 'when' without bound value.",
+                  "issues": [
+                    "KT-25268"
+                  ],
+                  "unexpectedBehaviour": true
+                }
+              ],
+              "description": "'When' least upper bound of the types check (when exhaustive via else branch)."
+            },
+            "2": {
+              "cases": [
+                {
+                  "description": "Checking all types except the Any (implicit cast to any) in 'when' with null-check branch."
+                },
+                {
+                  "description": "Checking all types except the Any (implicit cast to any) in 'when'."
+                },
+                {
+                  "description": "Checking all types except the correct one in 'when' with null-check branch."
+                },
+                {
+                  "description": "Checking all types except the correct one in 'when'."
+                }
+              ],
+              "description": "'When' least upper bound of the types check (when exhaustive via enum)."
+            },
+            "3": {
+              "cases": [
+                {
+                  "description": "Checking all types except the Any (implicit cast to any) in 'when' with null-check branch."
+                },
+                {
+                  "description": "Checking all types except the Any (implicit cast to any) in 'when'."
+                },
+                {
+                  "description": "Checking all types except the correct one in 'when' with null-check branch."
+                },
+                {
+                  "description": "Checking all types except the correct one in 'when'."
+                }
+              ],
+              "description": "'When' least upper bound of the types check (when exhaustive via boolean bound value)."
+            },
+            "4": {
+              "cases": [
+                {
+                  "description": "Checking all types except the Any (implicit cast to any) in 'when' with null-check branch."
+                },
+                {
+                  "description": "Checking all types except the Any (implicit cast to any) in 'when'."
+                },
+                {
+                  "description": "Checking all types except the correct one in 'when' with 'else' branch."
+                },
+                {
+                  "description": "Checking all types except the correct one in 'when' with null-check branch."
+                },
+                {
+                  "description": "Checking all types except the correct one in 'when'."
+                },
+                {
+                  "description": "Checking objects except the Any (implicit cast to any) in 'when' with null-check branch."
+                },
+                {
+                  "description": "Checking objects except the Any (implicit cast to any) in 'when'."
+                },
+                {
+                  "description": "Checking objects except the correct one in 'when' with null-check branch."
+                },
+                {
+                  "description": "Checking objects except the correct one in 'when'."
+                }
+              ],
+              "description": "'When' least upper bound of the types check (when exhaustive via sealed class)."
+            }
+          },
+          "pos": {
+            "1": {
+              "cases": [
+                {
+                  "description": "Checking Any type (implicit cast to any) in 'when' with bound value."
+                },
+                {
+                  "description": "Checking Any type (implicit cast to any) in 'when' without bound value."
+                },
+                {
+                  "description": "Checking correctness type (custom types) in 'when' with bound value."
+                },
+                {
+                  "description": "Checking correctness type (custom types) in 'when' without bound value."
+                },
+                {
+                  "description": "Checking correctness type (numbers) in 'when' with bound value.",
+                  "issues": [
+                    "KT-25268"
+                  ],
+                  "unexpectedBehaviour": true
+                },
+                {
+                  "description": "Checking correctness type (numbers) in 'when' without bound value.",
+                  "issues": [
+                    "KT-25268"
+                  ],
+                  "unexpectedBehaviour": true
+                }
+              ],
+              "description": "'When' least upper bound of the types check (when exhaustive via else branch)."
+            },
+            "2": {
+              "cases": [
+                {
+                  "description": "Checking Any type (implicit cast to any) in 'when' with null-check branch."
+                },
+                {
+                  "description": "Checking Any type (implicit cast to any) in 'when'."
+                },
+                {
+                  "description": "Checking correct type in 'when' with null-check branch."
+                },
+                {
+                  "description": "Checking correct type in 'when'."
+                }
+              ],
+              "description": "'When' least upper bound of the types check (when exhaustive via enum)."
+            },
+            "3": {
+              "cases": [
+                {
+                  "description": "Checking Any type (implicit cast to any) in 'when' with null-check branch."
+                },
+                {
+                  "description": "Checking Any type (implicit cast to any) in 'when'."
+                },
+                {
+                  "description": "Checking correct type in 'when' with null-check branch."
+                },
+                {
+                  "description": "Checking correct type in 'when'."
+                }
+              ],
+              "description": "'When' least upper bound of the types check (when exhaustive via boolean bound value)."
+            },
+            "4": {
+              "cases": [
+                {
+                  "description": "Checking Any type (implicit cast to any) in 'when' (equality with objects)."
+                },
+                {
+                  "description": "Checking Any type (implicit cast to any) in 'when' with null-check branch (equality with objects)."
+                },
+                {
+                  "description": "Checking Any type (implicit cast to any) in 'when' with null-check branch."
+                },
+                {
+                  "description": "Checking Any type (implicit cast to any) in 'when'."
+                },
+                {
+                  "description": "Checking correct basic type (Int) in 'when' with."
+                },
+                {
+                  "description": "Checking correct type in 'when' (equality with objects) with null-check branch."
+                },
+                {
+                  "description": "Checking correct type in 'when' (equality with objects)."
+                },
+                {
+                  "description": "Checking correct type in 'when' with null-check branch."
+                },
+                {
+                  "description": "Checking correct type in 'when'."
+                }
+              ],
+              "description": "'When' least upper bound of the types check (when exhaustive via sealed class)."
+            }
+          }
+        }
+      }
+    },
+    "11": {
+      "1": {
+        "diagnostics": {
+          "neg": {
+            "1": {
+              "cases": [
+                {
+                  "description": "Checking for not exhaustive 'when' (no branches)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' (one branch)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' (several branches)."
+                }
+              ],
+              "description": "Checking for not exhaustive when without bound value when there is no else branch."
+            },
+            "2": {
+              "cases": [
+                {
+                  "description": "Checking for not exhaustive 'when' (no branches)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' (one branch)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' (several branches)."
+                }
+              ],
+              "description": "Checking for not exhaustive when with bound value when there is no else branch."
+            }
+          },
+          "pos": {
+            "1": {
+              "cases": [
+                {
+                  "description": "Checking for exhaustive 'when' (only 'else' branch)."
+                },
+                {
+                  "description": "Checking for exhaustive 'when' (several value check branches and 'else' branch)."
+                },
+                {
+                  "description": "Checking for exhaustive 'when' (value check branch and 'else' branch)."
+                }
+              ],
+              "description": "Check when exhaustive via else entry (when without bound value)."
+            },
+            "2": {
+              "cases": [
+                {
+                  "description": "Checking for exhaustive 'when' (only 'else' branch)."
+                },
+                {
+                  "description": "Checking for exhaustive 'when' (several branches)."
+                },
+                {
+                  "description": "Checking for exhaustive 'when' (value check branch and 'else' branch)."
+                },
+                {
+                  "description": "Checking for exhaustive 'when' with constant bound value (value check branch and 'else' branch)."
+                }
+              ],
+              "description": "Check when exhaustive via else entry (when with bound value)."
+            },
+            "3": {
+              "cases": [
+                {
+                  "description": "Checking for redundant 'else' branch (all enum values and null value covered)."
+                },
+                {
+                  "description": "Checking for redundant 'else' branch (all enum values covered)."
+                },
+                {
+                  "description": "Checking for redundant 'else' branch (all sealed class subtypes and null value covered)."
+                },
+                {
+                  "description": "Checking for redundant 'else' branch (all sealed class subtypes covered)."
+                },
+                {
+                  "description": "Checking for redundant 'else' branch (both boolean value and null value covered)."
+                },
+                {
+                  "description": "Checking for redundant 'else' branch (both boolean value covered)."
+                },
+                {
+                  "description": "Checking for redundant 'else' branch (sealed class itself and null value covered)."
+                },
+                {
+                  "description": "Checking for redundant 'else' branch (sealed class itself covered)."
+                }
+              ],
+              "description": "Check when exhaustive via else entry (when with bound value, redundant else)."
+            }
+          }
+        }
+      },
+      "3": {
+        "diagnostics": {
+          "neg": {
+            "1": {
+              "cases": [
+                {
+                  "description": "Checking for not exhaustive 'when' on the Boolean value (no branches)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the Boolean value (with only false branch)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the Boolean value (with only true branch)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' with both Boolean values covered, but using variables."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' without bound value on the Boolean."
+                }
+              ],
+              "description": "Checking for not exhaustive 'when' when not contains by all Boolean values or 'when' does not have bound value."
+            }
+          },
+          "pos": {
+            "1": {
+              "cases": [
+                {
+                  "description": "Checking for exhaustive 'when' (both boolean value as complex expression covered)."
+                },
+                {
+                  "description": "Checking for exhaustive 'when' (both boolean value covered)."
+                }
+              ],
+              "description": "Check when exhaustive via boolean bound value and evaluating to value true and false."
+            }
+          }
+        }
+      },
+      "6": {
+        "diagnostics": {
+          "neg": {
+            "1": {
+              "cases": [
+                {
+                  "description": "Checking for not exhaustive 'when' on the Any."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the empty sealed class (without subtypes)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the not sealed class."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the sealed class (type checking and equality with object with enumeration)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the sealed class (type checking and equality with object)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the sealed class (type checking with enumeration)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the sealed class (type checking)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the sealed class (type checking)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the sealed class (type checking)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the sealed class with one subtype (no branches)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the sealed class with several subtypes (no branches)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' without bound value on the Sealed class with all subtypes covered."
+                }
+              ],
+              "description": "Checking for not exhaustive 'when' when not covered by all possible subtypes or 'when' does not have bound value."
+            }
+          },
+          "pos": {
+            "1": {
+              "cases": [
+                {
+                  "description": "Checking for exhaustive 'when' (all objects covered using implicit equality operator)."
+                },
+                {
+                  "description": "Checking for exhaustive 'when' (all sealed class subtypes covered)."
+                },
+                {
+                  "description": "Checking for exhaustive 'when' (all sealed class subtypes with methods covered)."
+                },
+                {
+                  "description": "Checking for exhaustive 'when' (all subtypes and objects (using type checking operator) covered)."
+                },
+                {
+                  "description": "Checking for exhaustive 'when' (all subtypes and objects covered)."
+                },
+                {
+                  "description": "Checking for exhaustive 'when' (single sealed class subtypes covered)."
+                },
+                {
+                  "description": "Checking for exhaustive 'when' on the empty sealed class (without subtypes)."
+                }
+              ],
+              "description": "Check when exhaustive when possible subtypes of the sealed class are covered."
+            }
+          }
+        }
+      },
+      "7": {
+        "diagnostics": {
+          "neg": {
+            "1": {
+              "cases": [
+                {
+                  "description": "Checking for not exhaustive 'when' on the Enum (not all values with enumerations)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the Enum (not all values)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the Enum (one branch)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the Enum with one value (no branches)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the Enum with several values (no branches)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the empty enum class."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' with all Enum values covered, but using variable."
+                }
+              ],
+              "description": "Checking for not exhaustive when when not covered by all enumerated values."
+            }
+          },
+          "pos": {
+            "1": {
+              "cases": [
+                {
+                  "description": "Checking for exhaustive 'when' (all enum values covered)."
+                },
+                {
+                  "description": "Checking for exhaustive 'when' (single enum value covered)."
+                }
+              ],
+              "description": "Check when exhaustive when all enumerated values are checked."
+            }
+          }
+        }
+      },
+      "8": {
+        "diagnostics": {
+          "neg": {
+            "1": {
+              "cases": [
+                {
+                  "description": "Checking for not exhaustive 'when' on the Boolean with null-check branch, but all possible values not covered."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the Boolean without branches."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the Boolean without null-check branch."
+                }
+              ],
+              "description": "Checking for not exhaustive 'when' on the nullable Boolean."
+            },
+            "2": {
+              "cases": [
+                {
+                  "description": "Checking for not exhaustive 'when' on opposite types."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on opposite types."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the empty nullable sealed class (without subtypes)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the empty sealed class (without subtypes)."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the nullable Any."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the nullable sealed class with all subtypes and objects covered without null-check branch."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the nullable sealed class with enumeration mixed checks (type and object check) and null-check branch."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the nullable sealed class with mixed checks (type and object check) and null-check branch."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the nullable sealed class with null-check branch and all subtypes covered, but objects not covered."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the nullable sealed class without branches."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the nullable sealed class without null-check branch and all subtypes covered, but objects not covered."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the nullable sealed class without null-check branch and only object covered."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the nullable sealed class without null-check branch."
+                }
+              ],
+              "description": "Checking for not exhaustive 'when' on the nullable sealed classes (and several checks for not sealed)."
+            },
+            "3": {
+              "cases": [
+                {
+                  "description": "Checking for not exhaustive 'when' on the Enum class (with only one value) with null-check branch, but value not covered."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the Enum class (with only one value) without null-check branch."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the Enum class with null-check branch, but all possible values not covered."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the Enum class with null-check branch, but all possible values not covered."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the Enum class without branches."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the Enum class without null-check branch."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the empty enum class."
+                },
+                {
+                  "description": "Checking for not exhaustive 'when' on the empty nullable enum class.",
+                  "issues": [
+                    "KT-26044"
+                  ],
+                  "unexpectedBehaviour": true
+                }
+              ],
+              "description": "Checking for not exhaustive 'when' on the nullable enums."
+            }
+          },
+          "pos": {
+            "1": {
+              "cases": [
+                {
+                  "description": "Checking for exhaustive 'when' (both boolean values and null value covered)."
+                },
+                {
+                  "description": "Checking for exhaustive 'when' (both boolean values as complex expressions and null value covered)."
+                }
+              ],
+              "description": "Check when exhaustive when boolean values are checked and contains a null check."
+            },
+            "2": {
+              "cases": [
+                {
+                  "description": "Checking for exhaustive 'when' (both enum values and null value covered)."
+                },
+                {
+                  "description": "Checking for exhaustive 'when' (single enum value and null value covered)."
+                }
+              ],
+              "description": "Check when exhaustive when enumerated values are checked and contains a null check."
+            },
+            "3": {
+              "cases": [
+                {
+                  "description": "Checking for exhaustive 'when' (all objects covered using implicit equality operator and null value covered)."
+                },
+                {
+                  "description": "Checking for exhaustive 'when' (all sealed class subtypes and null value covered)."
+                },
+                {
+                  "description": "Checking for exhaustive 'when' (all sealed class with methods subtypes and null value covered)."
+                },
+                {
+                  "description": "Checking for exhaustive 'when' (all subtypes and objects (using type checking operator) covered + null value covered)."
+                },
+                {
+                  "description": "Checking for exhaustive 'when' (all subtypes and objects covered + null value covered)."
+                },
+                {
+                  "description": "Checking for exhaustive 'when' (sealed class itself and null value covered)."
+                }
+              ],
+              "description": "Check when exhaustive when possible subtypes of the sealed class are covered and contains a null check."
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Examples:
- https://petukhovvictor.github.io/kotlin-spec/?mode=tests_linking#when-expression — linking to compiler tests.
- https://petukhovvictor.github.io/kotlin-spec/#when-expression:3:1 — linking to specified sentence (yellow highlight).

`tests-map.json` is generated by gradle task of `tests-spec` Kotlin compiler module.