### PR TITLE
Fix "Inconsistent formatting for rule alternatives", "Get rid of duplication in rule alternatives"

### DIFF
--- a/grammar/src/main/antlr/KotlinParser.g4
+++ b/grammar/src/main/antlr/KotlinParser.g4
@@ -60,10 +60,10 @@ declaration
 
 classDeclaration
     : modifiers? (CLASS | (FUN NL*)? INTERFACE) NL* simpleIdentifier
-    (NL* typeParameters)? (NL* primaryConstructor)?
-    (NL* COLON NL* delegationSpecifiers)?
-    (NL* typeConstraints)?
-    (NL* classBody | NL* enumClassBody)?
+      (NL* typeParameters)? (NL* primaryConstructor)?
+      (NL* COLON NL* delegationSpecifiers)?
+      (NL* typeConstraints)?
+      (NL* classBody | NL* enumClassBody)?
     ;
 
 primaryConstructor
@@ -140,9 +140,9 @@ anonymousInitializer
 
 companionObject
     : modifiers? COMPANION NL* OBJECT
-    (NL* simpleIdentifier)?
-    (NL* COLON NL* delegationSpecifiers)?
-    (NL* classBody)?
+      (NL* simpleIdentifier)?
+      (NL* COLON NL* delegationSpecifiers)?
+      (NL* classBody)?
     ;
 
 functionValueParameters
@@ -155,11 +155,11 @@ functionValueParameter
 
 functionDeclaration
     : modifiers?
-    FUN (NL* typeParameters)? (NL* receiverType NL* DOT)? NL* simpleIdentifier
-    NL* functionValueParameters
-    (NL* COLON NL* type)?
-    (NL* typeConstraints)?
-    (NL* functionBody)?
+      FUN (NL* typeParameters)? (NL* receiverType NL* DOT)? NL* simpleIdentifier
+      NL* functionValueParameters
+      (NL* COLON NL* type)?
+      (NL* typeConstraints)?
+      (NL* functionBody)?
     ;
 
 functionBody
@@ -177,12 +177,12 @@ multiVariableDeclaration
 
 propertyDeclaration
     : modifiers? (VAL | VAR)
-    (NL* typeParameters)?
-    (NL* receiverType NL* DOT)?
-    (NL* (multiVariableDeclaration | variableDeclaration))
-    (NL* typeConstraints)?
-    (NL* (ASSIGNMENT NL* expression | propertyDelegate))?
-    (NL+ SEMICOLON)? NL* (getter? (NL* semi? setter)? | setter? (NL* semi? getter)?)
+      (NL* typeParameters)?
+      (NL* receiverType NL* DOT)?
+      (NL* (multiVariableDeclaration | variableDeclaration))
+      (NL* typeConstraints)?
+      (NL* (ASSIGNMENT NL* expression | propertyDelegate))?
+      (NL+ SEMICOLON)? NL* (getter? (NL* semi? setter)? | setter? (NL* semi? getter)?)
     ;
 
 propertyDelegate
@@ -191,12 +191,12 @@ propertyDelegate
 
 getter
     : modifiers? GET
-    | modifiers? GET NL* LPAREN NL* RPAREN (NL* COLON NL* type)? NL* functionBody
+      (NL* LPAREN NL* RPAREN (NL* COLON NL* type)? NL* functionBody)?
     ;
 
 setter
     : modifiers? SET
-    | modifiers? SET NL* LPAREN NL* parameterWithOptionalType (NL* COMMA)? NL* RPAREN (NL* COLON NL* type)? NL* functionBody
+      (NL* LPAREN NL* parameterWithOptionalType (NL* COMMA)? NL* RPAREN (NL* COLON NL* type)? NL* functionBody)?
     ;
 
 parametersWithOptionalType
@@ -213,9 +213,9 @@ parameter
 
 objectDeclaration
     : modifiers? OBJECT
-    NL* simpleIdentifier
-    (NL* COLON NL* delegationSpecifiers)?
-    (NL* classBody)?
+      NL* simpleIdentifier
+      (NL* COLON NL* delegationSpecifiers)?
+      (NL* classBody)?
     ;
 
 secondaryConstructor
@@ -223,8 +223,7 @@ secondaryConstructor
     ;
 
 constructorDelegationCall
-    : THIS NL* valueArguments
-    | SUPER NL* valueArguments
+    : (THIS | SUPER) NL* valueArguments
     ;
 
 // SECTION: enumClasses
@@ -244,11 +243,7 @@ enumEntry
 // SECTION: types
 
 type
-    : typeModifiers?
-    ( parenthesizedType
-    | nullableType
-    | typeReference
-    | functionType)
+    : typeModifiers? (parenthesizedType | nullableType | typeReference | functionType)
     ;
 
 typeReference
@@ -274,7 +269,8 @@ simpleUserType
     ;
 
 typeProjection
-    : typeProjectionModifiers? type | MULT
+    : typeProjectionModifiers? type
+    | MULT
     ;
 
 typeProjectionModifiers
@@ -299,15 +295,11 @@ parenthesizedType
     ;
 
 receiverType
-    : typeModifiers?
-    ( parenthesizedType
-    | nullableType
-    | typeReference)
+    : typeModifiers? (parenthesizedType | nullableType | typeReference)
     ;
 
 parenthesizedUserType
-    : LPAREN NL* userType NL* RPAREN
-    | LPAREN NL* parenthesizedUserType NL* RPAREN
+    : LPAREN NL* (userType | parenthesizedUserType) NL* RPAREN
     ;
 
 // SECTION: statements
@@ -317,11 +309,7 @@ statements
     ;
 
 statement
-    : (label | annotation)*
-    ( declaration
-    | assignment
-    | loopStatement
-    | expression)
+    : (label | annotation)* ( declaration | assignment | loopStatement | expression)
     ;
 
 label
@@ -344,12 +332,12 @@ loopStatement
     ;
 
 forStatement
-    : FOR NL* LPAREN annotation* (variableDeclaration | multiVariableDeclaration) IN expression RPAREN NL* controlStructureBody?
+    : FOR NL* LPAREN annotation* (variableDeclaration | multiVariableDeclaration)
+      IN expression RPAREN NL* controlStructureBody?
     ;
 
 whileStatement
-    : WHILE NL* LPAREN expression RPAREN NL* controlStructureBody
-    | WHILE NL* LPAREN expression RPAREN NL* SEMICOLON
+    : WHILE NL* LPAREN expression RPAREN NL* (controlStructureBody | SEMICOLON)
     ;
 
 doWhileStatement
@@ -357,13 +345,13 @@ doWhileStatement
     ;
 
 assignment
-    : directlyAssignableExpression ASSIGNMENT NL* expression
-    | assignableExpression assignmentAndOperator NL* expression
+    : (directlyAssignableExpression ASSIGNMENT | assignableExpression assignmentAndOperator) NL* expression
     ;
 
 semi
     : (SEMICOLON | NL) NL*
-    | EOF;
+    | EOF
+    ;
 
 semis
     : (SEMICOLON | NL)+
@@ -439,8 +427,7 @@ unaryPrefix
     ;
 
 postfixUnaryExpression
-    : primaryExpression
-    | primaryExpression postfixUnarySuffix+
+    : primaryExpression postfixUnarySuffix*
     ;
 
 postfixUnarySuffix
@@ -462,7 +449,8 @@ parenthesizedDirectlyAssignableExpression
     ;
 
 assignableExpression
-    : prefixUnaryExpression | parenthesizedAssignableExpression
+    : prefixUnaryExpression
+    | parenthesizedAssignableExpression
     ;
 
 parenthesizedAssignableExpression
@@ -484,8 +472,7 @@ navigationSuffix
     ;
 
 callSuffix
-    : typeArguments? valueArguments? annotatedLambda
-    | typeArguments? valueArguments
+    : typeArguments? (valueArguments? annotatedLambda | valueArguments)
     ;
 
 annotatedLambda
@@ -497,8 +484,7 @@ typeArguments
     ;
 
 valueArguments
-    : LPAREN NL* RPAREN
-    | LPAREN NL* valueArgument (NL* COMMA NL* valueArgument)* (NL* COMMA)? NL* RPAREN
+    : LPAREN NL* (valueArgument (NL* COMMA NL* valueArgument)* (NL* COMMA)? NL*)? RPAREN
     ;
 
 valueArgument
@@ -527,8 +513,7 @@ parenthesizedExpression
     ;
 
 collectionLiteral
-    : LSQUARE NL* expression (NL* COMMA NL* expression)* (NL* COMMA)? NL* RSQUARE
-    | LSQUARE NL* RSQUARE
+    : LSQUARE NL* (expression (NL* COMMA NL* expression)* (NL* COMMA)? NL*)? RSQUARE
     ;
 
 literalConstant
@@ -577,8 +562,7 @@ multiLineStringExpression
     ;
 
 lambdaLiteral
-    : LCURL NL* statements NL* RCURL
-    | LCURL NL* lambdaParameters? NL* ARROW NL* statements NL* RCURL
+    : LCURL NL* (lambdaParameters? NL* ARROW NL*)? statements NL* RCURL
     ;
 
 lambdaParameters
@@ -592,11 +576,11 @@ lambdaParameter
 
 anonymousFunction
     : FUN
-    (NL* type NL* DOT)?
-    NL* parametersWithOptionalType
-    (NL* COLON NL* type)?
-    (NL* typeConstraints)?
-    (NL* functionBody)?
+      (NL* type NL* DOT)?
+      NL* parametersWithOptionalType
+      (NL* COLON NL* type)?
+      (NL* typeConstraints)?
+      (NL* functionBody)?
     ;
 
 functionLiteral
@@ -605,8 +589,7 @@ functionLiteral
     ;
 
 objectLiteral
-    : OBJECT NL* COLON NL* delegationSpecifiers NL* classBody
-    | OBJECT NL* classBody
+    : OBJECT NL* (COLON NL* delegationSpecifiers NL*)? classBody
     ;
 
 thisExpression
@@ -620,8 +603,10 @@ superExpression
     ;
 
 ifExpression
-    : IF NL* LPAREN NL* expression NL* RPAREN NL* (controlStructureBody | SEMICOLON)
-    | IF NL* LPAREN NL* expression NL* RPAREN NL* controlStructureBody? NL* SEMICOLON? NL* ELSE NL* (controlStructureBody | SEMICOLON)
+    : IF NL* LPAREN NL* expression NL* RPAREN NL*
+      ( controlStructureBody
+      | controlStructureBody? NL* SEMICOLON? NL* ELSE NL* (controlStructureBody | SEMICOLON)
+      | SEMICOLON)
     ;
 
 whenSubject
@@ -666,12 +651,14 @@ finallyBlock
 jumpExpression
     : THROW NL* expression
     | (RETURN | RETURN_AT) expression?
-    | CONTINUE | CONTINUE_AT
-    | BREAK | BREAK_AT
+    | CONTINUE
+    | CONTINUE_AT
+    | BREAK
+    | BREAK_AT
     ;
 
 callableReference
-    : (receiverType? NL* COLONCOLON NL* (simpleIdentifier | CLASS))
+    : receiverType? NL* COLONCOLON NL* (simpleIdentifier | CLASS)
     ;
 
 assignmentAndOperator
@@ -697,15 +684,18 @@ comparisonOperator
     ;
 
 inOperator
-    : IN | NOT_IN
+    : IN
+    | NOT_IN
     ;
 
 isOperator
-    : IS | NOT_IS
+    : IS
+    | NOT_IS
     ;
 
 additiveOperator
-    : ADD | SUB
+    : ADD
+    | SUB
     ;
 
 multiplicativeOperator
@@ -739,7 +729,9 @@ excl
     ;
 
 memberAccessOperator
-    : DOT | safeNav | COLONCOLON
+    : DOT
+    | safeNav
+    | COLONCOLON
     ;
 
 safeNav
@@ -772,7 +764,8 @@ typeModifiers
     ;
 
 typeModifier
-    : annotation | SUSPEND NL*
+    : annotation
+    | SUSPEND NL*
     ;
 
 classModifier
@@ -851,13 +844,11 @@ annotation
     ;
 
 singleAnnotation
-    : annotationUseSiteTarget NL* unescapedAnnotation
-    | (AT_NO_WS | AT_PRE_WS) unescapedAnnotation
+    : (annotationUseSiteTarget NL* | AT_NO_WS | AT_PRE_WS) unescapedAnnotation
     ;
 
 multiAnnotation
-    : annotationUseSiteTarget NL* LSQUARE unescapedAnnotation+ RSQUARE
-    | (AT_NO_WS | AT_PRE_WS) LSQUARE unescapedAnnotation+ RSQUARE
+    : (annotationUseSiteTarget NL* | AT_NO_WS | AT_PRE_WS) LSQUARE unescapedAnnotation+ RSQUARE
     ;
 
 annotationUseSiteTarget
@@ -871,7 +862,8 @@ unescapedAnnotation
 
 // SECTION: identifiers
 
-simpleIdentifier: Identifier
+simpleIdentifier
+    : Identifier
     | ABSTRACT
     | ANNOTATION
     | BY


### PR DESCRIPTION
Fix "Inconsistent formatting for rule alternatives" (fix #36), "Get rid of duplication in rule alternatives" (fix #35), clear up

Max line length = 120