### PR TITLE
Update library versions + move to Kotlin Multiplatform

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import at.phatbl.shellexec.ShellExec
 
 plugins {
-    kotlin("jvm") version "1.9.10" apply false
+    kotlin("jvm") version "1.9.23" apply false
     id("at.phatbl.shellexec") version "1.5.2"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,12 @@
 import at.phatbl.shellexec.ShellExec
 
 plugins {
-    kotlin("jvm") version "1.7.0" apply false
+    kotlin("jvm") version "1.9.10" apply false
     id("at.phatbl.shellexec") version "1.5.2"
 }
 
-val htmlBuildDir = "$buildDir/spec/html"
-val pdfBuildDir = "$buildDir/spec/pdf"
+val htmlBuildDir = "${layout.buildDirectory.get()}/spec/html"
+val pdfBuildDir = "${layout.buildDirectory.get()}/spec/pdf"
 val resourcesBuildDir = "$htmlBuildDir/resources"
 val jsBuildDir = "$resourcesBuildDir/js"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,12 +12,11 @@ RUN apt-get update
 RUN apt-get install -y zulu-11
 
 # install packages for the Kotlin spec
-RUN apt-get install -y git
-RUN apt-get install -y gpp
-RUN apt-get install -y librsvg2-bin
-RUN apt-get install -y npm
-RUN apt-get install -y curl
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
+RUN apt-get install -y ca-certificates curl gnupg git gpp librsvg2-bin
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update
 RUN apt-get install -y nodejs
 
 # install more TeX Live packages

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM pandoc/latex:2.14.2-ubuntu
+FROM pandoc/latex:3.1.1-ubuntu
 MAINTAINER Marat Akhin <marat.akhin@jetbrains.com>
 
 WORKDIR /source

--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -10,8 +10,8 @@ plugins {
 group = "org.jetbrains.kotlin.spec"
 version = "0.1"
 
-val htmlBuildDir = "$buildDir/spec/html"
-val pdfBuildDir = "$buildDir/spec/pdf"
+val htmlBuildDir = "${layout.buildDirectory.get()}/spec/html"
+val pdfBuildDir = "${layout.buildDirectory.get()}/spec/pdf"
 val resourcesBuildDir = "$htmlBuildDir/resources"
 val jsBuildDir = "$resourcesBuildDir/js"
 val scriptsDir = "$projectDir/scripts/build"
@@ -22,6 +22,10 @@ repositories {
         url = URI("https://maven.vorpal-research.science")
     }
     mavenCentral()
+}
+
+kotlin {
+    jvmToolchain(11)
 }
 
 sourceSets {
@@ -40,7 +44,7 @@ dependencies {
         }
     }
     implementation("com.github.ajalt:clikt:2.8.0")
-    implementation("com.zaxxer:nuprocess:2.0.3")
+    implementation("com.zaxxer:nuprocess:2.0.6")
     implementation("org.antlr:antlr4:4.8")
 }
 
@@ -91,12 +95,12 @@ tasks.create("prepareShell") {
 
             if (enableStaticMath) {
                 appendLine("STATIC_MATH_OPTION=--enable-static-math")
-                appendLine("KATEX_BIN_OPTION=\"--katex=${rootProject.buildDir}/js/node_modules/.bin/katex\"")
+                appendLine("KATEX_BIN_OPTION=\"--katex=${rootProject.layout.buildDirectory.get()}/js/node_modules/.bin/katex\"")
             }
             else appendLine("STATIC_MATH_OPTION=--disable-static-math")
         }
 
-        File("$buildDir/prepare.sh").writeText("$res")
+        File("${layout.buildDirectory.get()}/prepare.sh").writeText("$res")
     }
 
 }

--- a/docs/html/build.gradle.kts
+++ b/docs/html/build.gradle.kts
@@ -1,4 +1,4 @@
-val htmlBuildDir = "${project.parent?.buildDir}/spec/html"
+val htmlBuildDir = "${project.parent?.layout?.buildDirectory?.get()}/spec/html"
 val scriptsDir = "${project.parent?.projectDir}/scripts/build"
 
 tasks.create<Exec>("build") {

--- a/docs/htmlSections/build.gradle.kts
+++ b/docs/htmlSections/build.gradle.kts
@@ -1,6 +1,6 @@
 import java.nio.file.Paths
 
-val htmlBuildDir = "${project.parent?.buildDir}/spec/html"
+val htmlBuildDir = "${project.parent?.layout?.buildDirectory?.get()}/spec/html"
 val scriptsDir = "${project.parent?.projectDir}/scripts/build"
 
 tasks.create<Exec>("build") {

--- a/docs/pdf/build.gradle.kts
+++ b/docs/pdf/build.gradle.kts
@@ -1,4 +1,4 @@
-val pdfBuildDir = "${project.parent?.buildDir}/spec/pdf"
+val pdfBuildDir = "${project.parent?.layout?.buildDirectory}/spec/pdf"
 val scriptsDir = "${project.parent?.projectDir}/scripts/build"
 
 tasks.create<Exec>("build") {

--- a/docs/pdfSections/build.gradle.kts
+++ b/docs/pdfSections/build.gradle.kts
@@ -1,6 +1,6 @@
 import java.nio.file.Paths
 
-val pdfBuildDir = "${project.parent?.buildDir}/spec/pdf"
+val pdfBuildDir = "${project.parent?.layout?.buildDirectory?.get()}/spec/pdf"
 val scriptsDir = "${project.parent?.projectDir}/scripts/build"
 
 tasks.create<Exec>("build") {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/grammar/build.gradle.kts
+++ b/grammar/build.gradle.kts
@@ -5,7 +5,7 @@ import java.util.regex.Pattern
 
 plugins {
     idea
-    id("org.jetbrains.intellij") version "1.15.0"
+    id("org.jetbrains.intellij") version "1.17.3"
     antlr
     `maven-publish`
     kotlin("jvm")
@@ -47,11 +47,19 @@ sourceSets {
 
 dependencies {
     implementation("junit:junit:4.13.2")
-    antlr("org.antlr:antlr4:4.8")
+    antlr("org.antlr:antlr4:4.13.1")
 }
 
 tasks.compileKotlin {
     dependsOn("generateGrammarSource")
+}
+
+java {
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+kotlin {
+    jvmToolchain(11)
 }
 
 intellij {

--- a/grammar/build.gradle.kts
+++ b/grammar/build.gradle.kts
@@ -5,7 +5,7 @@ import java.util.regex.Pattern
 
 plugins {
     idea
-    id("org.jetbrains.intellij") version "1.6.0"
+    id("org.jetbrains.intellij") version "1.15.0"
     antlr
     `maven-publish`
     kotlin("jvm")
@@ -155,9 +155,9 @@ tasks.create("prepareDiagnosticsCompilerTests") {
 
 val instrumentTestCodeTask = tasks.named("instrumentTestCode")
 
-tasks.named("inspectClassesForKotlinIC") {
-    dependsOn(instrumentTestCodeTask)
-}
+// tasks.named("inspectClassesForKotlinIC") {
+//     dependsOn(instrumentTestCodeTask)
+// }
 
 tasks.withType<Jar> {
     dependsOn(instrumentTestCodeTask)

--- a/grammar/build.gradle.kts
+++ b/grammar/build.gradle.kts
@@ -172,5 +172,7 @@ tasks.withType<Jar> {
         )
     }
 
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+
     from(configurations.runtimeClasspath.get().files.map { if (it.isDirectory) it else zipTree(it) })
 }

--- a/grammar/gradle/wrapper/gradle-wrapper.properties
+++ b/grammar/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -23,7 +23,7 @@ tasks.create<Copy>("copyKatex") {
 }
 
 kotlin {
-    js {
+    js(IR) {
         moduleName = "main"
         compilations.all {
             packageJson {
@@ -34,6 +34,7 @@ kotlin {
                 moduleKind = "amd"
             }
         }
+        binaries.executable()
         browser {
             webpackTask(Action {
                 dependsOn("copyKatex")
@@ -56,10 +57,10 @@ kotlin {
         val jsMain by getting {
             kotlin.srcDir("src/main/kotlin")
             dependencies {
-                implementation(npm("katex", "0.16.8"))
+                implementation(npm("katex", "0.16.10"))
                 implementation(npm("jquery", "2.2.4"))
-                implementation(npm("kotlin-playground", "1.28.0"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
+                implementation(npm("kotlin-playground", "1.30.0"))
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
             }
         }
     }

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig.Mode
 import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackOutput
 
 plugins {
-    kotlin("js")
+    kotlin("multiplatform")
 }
 
 group = "org.jetbrains.kotlin.spec"
@@ -12,7 +12,6 @@ val buildMode = findProperty("mode")?.toString() ?: "production" // production |
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 tasks.create<Copy>("copyKatex") {
@@ -20,7 +19,7 @@ tasks.create<Copy>("copyKatex") {
     group = "internal"
 
     from("$rootDir/build/js/node_modules/katex/dist")
-    into("$buildDir/js/katex".also { File(it).mkdirs() })
+    into("${layout.buildDirectory.get()}/js/katex".also { File(it).mkdirs() })
 }
 
 kotlin {
@@ -36,7 +35,7 @@ kotlin {
             }
         }
         browser {
-            webpackTask {
+            webpackTask(Action {
                 dependsOn("copyKatex")
 
                 output.apply {
@@ -44,23 +43,23 @@ kotlin {
                     library = "main"
                 }
 
-                destinationDirectory = file("${buildDir}/js")
-                outputFileName = "main.js"
+                outputDirectory = file("${layout.buildDirectory.get()}/js")
+                mainOutputFileName = "main.js"
 
-                mode = Mode.valueOf(buildMode.toUpperCase())
+                mode = Mode.valueOf(buildMode.uppercase())
                 sourceMaps = (mode == Mode.DEVELOPMENT)
-            }
+            })
         }
     }
 
     sourceSets {
-        main {
+        val jsMain by getting {
+            kotlin.srcDir("src/main/kotlin")
             dependencies {
-                compileOnly("kotlin.js.externals:kotlin-js-jquery:2.0.0-0")
-                implementation(npm("katex", "0.11.1"))
+                implementation(npm("katex", "0.16.8"))
                 implementation(npm("jquery", "2.2.4"))
-                implementation(npm("kotlin-playground", "1.24.2"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime-js:0.12.0")
+                implementation(npm("kotlin-playground", "1.28.0"))
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
             }
         }
     }

--- a/web/src/main/kotlin/org/jetbrains/kotlin/spec/JQuery.kt
+++ b/web/src/main/kotlin/org/jetbrains/kotlin/spec/JQuery.kt
@@ -1,0 +1,88 @@
+package org.jetbrains.kotlin.spec
+
+import org.w3c.dom.Element
+import org.w3c.dom.HTMLElement
+
+@JsModule("jquery")
+@JsNonModule
+external fun `$`(selector: dynamic): JQuery
+
+@JsModule("jquery")
+@JsNonModule
+external interface JQueryCoordinates {
+    var left: Number
+    var top: Number
+}
+
+@JsModule("jquery")
+@JsNonModule
+external interface JQueryEventObject {
+    fun stopPropagation()
+    var currentTarget: Element
+    var target: Element
+    var keyCode: Number
+    var offsetX: Number
+    var offsetY: Number
+}
+
+@JsModule("jquery")
+@JsNonModule
+external interface JQuery {
+    fun offset(): JQueryCoordinates
+    operator fun get(index: Number): HTMLElement?
+    fun ready(handler: (jQueryAlias: Any? /*= null*/) -> Any): JQuery
+    fun attr(attributeName: String): String
+    fun prop(propertyName: String): Any
+    fun contents(): JQuery
+    fun addClass(className: String): JQuery
+    fun removeClass(className: String): JQuery
+    fun hasClass(className: String): Boolean
+    fun toggleClass(className: String, swtch: Boolean? = definedExternally /* null */): JQuery
+    fun prepend(content1: String, vararg content2: Any): JQuery
+    fun append(content1: String, vararg content2: Any): JQuery
+    fun appendTo(target: String): JQuery
+    fun data(key: String, value: Any): JQuery
+    fun data(key: String): Any
+    fun data(): Any
+    fun get(): Array<HTMLElement>
+    fun children(selector: String? = definedExternally /* null */): JQuery
+    fun clone(withDataAndEvents: Boolean? = definedExternally /* null */, deepWithDataAndEvents: Boolean? = definedExternally /* null */): JQuery
+    fun eq(index: Number): JQuery
+    fun each(func: (index: Number, elem: Element) -> Any?): JQuery
+    fun empty(): JQuery
+    fun filter(func: (index: Number, element: Element) -> Any): JQuery
+    fun find(selector: String): JQuery
+    fun find(element: Element): JQuery
+    fun find(obj: JQuery): JQuery
+    fun first(): JQuery
+    fun `is`(selector: String): Boolean
+    var length: Number
+    fun parent(selector: String? = definedExternally /* null */): JQuery
+    fun parents(selector: String? = definedExternally /* null */): JQuery
+    fun next(selector: String? = definedExternally /* null */): JQuery
+    fun nextAll(selector: String? = definedExternally /* null */): JQuery
+    fun prevAll(selector: String? = definedExternally /* null */): JQuery
+    fun remove(selector: String? = definedExternally /* null */): JQuery
+    fun before(content1: String, vararg content2: Any): JQuery
+    fun html(htmlString: String): JQuery
+    fun css(propertyName: String, value: String): JQuery
+    fun css(propertyName: String, value: Number): JQuery
+    fun text(): String
+    fun focus(): JQuery
+    fun select(): JQuery
+    fun click(): JQuery
+    fun keydown(handler: (eventObject: JQueryEventObject) -> Any): JQuery
+    fun keyup(handler: (eventObject: JQueryEventObject) -> Any): JQuery
+    fun width(): Number
+    fun height(): Number
+    fun fadeTo(duration: Number, opacity: Number, easing: String? = definedExternally /* null */, complete: Function<*>? = definedExternally /* null */): JQuery
+    fun show(duration: Number? = definedExternally /* null */, complete: Function<*>? = definedExternally /* null */): JQuery
+    fun toggle(duration: Number? = definedExternally /* null */, complete: Function<*>? = definedExternally /* null */): JQuery
+    fun on(events: String, handler: (eventObject: JQueryEventObject, args: Any) -> Any): JQuery
+    fun on(events: String, selector: String, handler: (eventObject: JQueryEventObject, eventData: Any) -> Any): JQuery
+    fun scroll(handler: (eventObject: JQueryEventObject) -> Any): JQuery
+    fun scrollTop(): Number
+    fun scrollTop(value: Number): JQuery
+    fun `val`(): Any
+    fun `val`(value: String): JQuery
+}

--- a/web/src/main/kotlin/org/jetbrains/kotlin/spec/JQuery.kt
+++ b/web/src/main/kotlin/org/jetbrains/kotlin/spec/JQuery.kt
@@ -10,7 +10,7 @@ external fun `$`(selector: dynamic): JQuery
 @JsModule("jquery")
 @JsNonModule
 external interface JQueryCoordinates {
-    var left: Number
+    // var left: Number
     var top: Number
 }
 
@@ -21,7 +21,7 @@ external interface JQueryEventObject {
     var currentTarget: Element
     var target: Element
     var keyCode: Number
-    var offsetX: Number
+    // var offsetX: Number
     var offsetY: Number
 }
 

--- a/web/src/main/kotlin/org/jetbrains/kotlin/spec/entity/test/parameters/TestInfo.kt
+++ b/web/src/main/kotlin/org/jetbrains/kotlin/spec/entity/test/parameters/TestInfo.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.kotlin.spec.entity.test.parameters
 
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 /** contains all options which could be defined in testMap.json's tests */
 private enum class TestElementKey(val value: String) {
@@ -26,13 +27,13 @@ class TestInfo(jsonSpecTestInfo: JsonObject, val testNumber: Int) {
 
 
     init {
-        fun parse(testElementKey: TestElementKey) = jsonSpecTestInfo[testElementKey.value]?.primitive?.content
+        fun parse(testElementKey: TestElementKey) = jsonSpecTestInfo[testElementKey.value]?.jsonPrimitive?.content
         specVersion = parse(TestElementKey.SPEC_VERSION) ?: ""
         casesNumber = parse(TestElementKey.CASES_NUMBER)?.toInt() ?: 1
         description = parse(TestElementKey.DESCRIPTION) ?: ""
         path = parse(TestElementKey.PATH) ?: ""
         unexpectedBehaviour = parse(TestElementKey.UNEXPECTED_BEHAVIOUR)?.toBoolean() ?: false
         linkType = parse(TestElementKey.LINK_TYPE)?.let { LinkType.valueOf(it) } ?: LinkType.main
-        helpers = parse(TestElementKey.HELPERS)?.split(",")?.map { it -> it.trim() }?.toSet() ?: emptySet()
+        helpers = parse(TestElementKey.HELPERS)?.split(",")?.map(String::trim)?.toSet() ?: emptySet()
     }
 }

--- a/web/src/main/kotlin/org/jetbrains/kotlin/spec/loader/SpecTestsLoader.kt
+++ b/web/src/main/kotlin/org/jetbrains/kotlin/spec/loader/SpecTestsLoader.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.kotlin.spec.loader
 
-import js.externals.jquery.JQuery
-import js.externals.jquery.`$`
+import org.jetbrains.kotlin.spec.`$`
 import org.jetbrains.kotlin.spec.entity.TestsLoadingInfo
 import org.jetbrains.kotlin.spec.entity.SpecSection
 import org.jetbrains.kotlin.spec.entity.test.parameters.testArea.TestArea
@@ -10,6 +9,7 @@ import org.jetbrains.kotlin.spec.utils.isDevMode
 import org.jetbrains.kotlin.spec.viewer.MarkUpArranger
 import org.jetbrains.kotlin.spec.viewer.SpecCoverageHighlighter
 import kotlinx.browser.window
+import org.jetbrains.kotlin.spec.JQuery
 import kotlin.js.Promise
 
 class SpecTestsLoader {
@@ -55,7 +55,7 @@ class SpecTestsLoader {
 
         fun getParagraphsInfo(sectionElement: JQuery): List<Map<String, Any>>? {
             var nextSibling = sectionElement.get().run {
-                if (size == 0) return@getParagraphsInfo null
+                if (isEmpty()) return@getParagraphsInfo null
                 this[0].nextElementSibling
             }
             val sectionName = sectionElement.attr("id")

--- a/web/src/main/kotlin/org/jetbrains/kotlin/spec/main.kt
+++ b/web/src/main/kotlin/org/jetbrains/kotlin/spec/main.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.kotlin.spec
 
-import js.externals.jquery.`$`
 import org.jetbrains.kotlin.spec.loader.SpecTestsLoader
 import org.jetbrains.kotlin.spec.utils.*
 import org.jetbrains.kotlin.spec.viewer.Header

--- a/web/src/main/kotlin/org/jetbrains/kotlin/spec/utils/Popup.kt
+++ b/web/src/main/kotlin/org/jetbrains/kotlin/spec/utils/Popup.kt
@@ -1,8 +1,8 @@
 package org.jetbrains.kotlin.spec.utils
 
-import js.externals.jquery.`$`
 import kotlinx.browser.document
 import kotlinx.browser.window
+import org.jetbrains.kotlin.spec.`$`
 import kotlin.math.round
 
 data class PopupConfig(

--- a/web/src/main/kotlin/org/jetbrains/kotlin/spec/viewer/Header.kt
+++ b/web/src/main/kotlin/org/jetbrains/kotlin/spec/viewer/Header.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlin.spec.viewer
 
-import js.externals.jquery.`$`
+import org.jetbrains.kotlin.spec.`$`
 import org.jetbrains.kotlin.spec.utils.format
 import org.jetbrains.kotlin.spec.utils.isDevMode
 import org.jetbrains.kotlin.spec.utils.shouldBeShowedMarkup

--- a/web/src/main/kotlin/org/jetbrains/kotlin/spec/viewer/MarkUpArranger.kt
+++ b/web/src/main/kotlin/org/jetbrains/kotlin/spec/viewer/MarkUpArranger.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.kotlin.spec.viewer
 
-import js.externals.jquery.JQuery
-import js.externals.jquery.`$`
+import org.jetbrains.kotlin.spec.`$`
+import org.jetbrains.kotlin.spec.JQuery
 import org.jetbrains.kotlin.spec.utils.format
 import org.w3c.dom.HTMLElement
 

--- a/web/src/main/kotlin/org/jetbrains/kotlin/spec/viewer/Sidebar.kt
+++ b/web/src/main/kotlin/org/jetbrains/kotlin/spec/viewer/Sidebar.kt
@@ -1,11 +1,11 @@
 package org.jetbrains.kotlin.spec.viewer
 
-import js.externals.jquery.JQuery
-import js.externals.jquery.`$`
 import org.w3c.dom.HTMLInputElement
 import org.w3c.dom.events.KeyboardEvent
 import kotlinx.browser.document
 import kotlinx.browser.window
+import org.jetbrains.kotlin.spec.`$`
+import org.jetbrains.kotlin.spec.JQuery
 
 object Sidebar {
     private const val LOAD_PDF_ICON = "./resources/images/pdf.png"
@@ -38,7 +38,7 @@ object Sidebar {
         val sectionIdFromHash = window.location.hash.removePrefix("#")
         val sectionIdFromPath = window.location.pathname.split("/").last().removeSuffix(".html")
 
-        expandItemsHierarchy(if (sectionIdFromHash.isNotBlank()) sectionIdFromHash else sectionIdFromPath)
+        expandItemsHierarchy(sectionIdFromHash.ifBlank { sectionIdFromPath })
 
         if (shouldScrollToItem) {
             scrollToActiveItem()
@@ -160,7 +160,7 @@ object Sidebar {
         `$`("h2").each { _, el ->
             val sectionName = `$`(el).attr("id")
             `$`(el).append("<a href=\"./pdf/sections/$sectionName.pdf\" target=\"_blank\" onclick=\"event.stopPropagation();\" class=\"download-section-as-pdf-text-link\" title=\"Download section as pdf\">"
-                    + """<img src="${LOAD_PDF_ICON}" />""".trimIndent() + "</a>")
+                    + """<img src="$LOAD_PDF_ICON" />""".trimIndent() + "</a>")
         }
     }
 }

--- a/web/src/main/kotlin/org/jetbrains/kotlin/spec/viewer/SpecCoverageHighlighter.kt
+++ b/web/src/main/kotlin/org/jetbrains/kotlin/spec/viewer/SpecCoverageHighlighter.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.kotlin.spec.viewer
 
-import js.externals.jquery.JQuery
-import js.externals.jquery.`$`
+import org.jetbrains.kotlin.spec.`$`
+import org.jetbrains.kotlin.spec.JQuery
 import org.jetbrains.kotlin.spec.entity.SpecParagraph
 import org.jetbrains.kotlin.spec.entity.SpecSection
 import org.jetbrains.kotlin.spec.entity.SpecSentence

--- a/web/src/main/kotlin/org/jetbrains/kotlin/spec/viewer/SpecTestsViewer.kt
+++ b/web/src/main/kotlin/org/jetbrains/kotlin/spec/viewer/SpecTestsViewer.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.kotlin.spec.viewer
 
-import js.externals.jquery.JQuery
-import js.externals.jquery.`$`
+import org.jetbrains.kotlin.spec.`$`
+import org.jetbrains.kotlin.spec.JQuery
 import org.jetbrains.kotlin.spec.entity.SpecSentence
 import org.jetbrains.kotlin.spec.entity.test.SpecTest
 import org.jetbrains.kotlin.spec.entity.test.TestCase
@@ -145,7 +145,7 @@ class SpecTestsViewer {
     fun onTestAreaChange() {
         val testArea = TestArea.getByShortName(`$`(TEST_AREA_SELECTOR).`val`().toString().apply { if (isEmpty()) return })
         currentSpecSentenceTests.getTests(testArea) ?: return
-        TestType.values().forEach { testType ->
+        TestType.entries.forEach { testType ->
             val tests = currentSpecSentenceTests.getTests(testArea, testType) ?: return@forEach
             if (tests.isNotEmpty())
                 `$`(TEST_TYPE_SELECTOR).append(TEST_TYPE_OPTION_TEMPLATE.format(testType.shortName, testType.name))

--- a/web/src/main/kotlin/org/jetbrains/kotlin/spec/viewer/links/SentenceFinder.kt
+++ b/web/src/main/kotlin/org/jetbrains/kotlin/spec/viewer/links/SentenceFinder.kt
@@ -1,6 +1,6 @@
 package org.jetbrains.kotlin.spec.viewer.links
 
-import js.externals.jquery.`$`
+import org.jetbrains.kotlin.spec.`$`
 import org.jetbrains.kotlin.spec.viewer.links.SpecPlaceHighlighter.getSentenceInfoFromSearchField
 import org.jetbrains.kotlin.spec.viewer.links.SpecPlaceHighlighter.highlightParagraph
 import org.jetbrains.kotlin.spec.viewer.links.SpecPlaceHighlighter.highlightSentence

--- a/web/src/main/kotlin/org/jetbrains/kotlin/spec/viewer/links/SpecPlaceHighlighter.kt
+++ b/web/src/main/kotlin/org/jetbrains/kotlin/spec/viewer/links/SpecPlaceHighlighter.kt
@@ -1,11 +1,11 @@
 package org.jetbrains.kotlin.spec.viewer.links
 
-import js.externals.jquery.JQuery
-import js.externals.jquery.`$`
 import org.jetbrains.kotlin.spec.loader.SpecTestsLoader
 import org.jetbrains.kotlin.spec.utils.*
 import org.w3c.dom.HTMLElement
 import kotlinx.browser.window
+import org.jetbrains.kotlin.spec.`$`
+import org.jetbrains.kotlin.spec.JQuery
 
 data class SpecPlaceComponents(
         val sectionId: String,


### PR DESCRIPTION
This PR updates several library versions. More importantly, it updates to Kotlin 1.9.10, and recent version of `kotlinx-serialization`. As a result, it moves from the old Kotlin/JS into Kotlin Multiplatform. Since there's no longer support for the old JQuery type library, this PR moves the necessary interface definitions into the project itself.