### PR TITLE
Fix typo

### DIFF
--- a/docs/src/md/kotlin.core/overload-resolution.md
+++ b/docs/src/md/kotlin.core/overload-resolution.md
@@ -371,7 +371,7 @@ Second, the following constraint system is built:
 - For every non-lambda argument inferred to have type $T_i$, corresponding to the function parameter of type $U_j$, a constraint $T_i <: U_j$ is constructed;
 - All declaration-site type constraints for the function are also added to the constraint system;
 - For every lambda argument with the number of lambda arguments known to be $K$, corresponding to the function parameter of type $U_m$, a special constraint of the form [$\left(\FT(L_1, \ldots, L_K) \rightarrow R \amp \FTR(\RT, L_1, \ldots, L_n) \rightarrow R\right) <: U_m$][Function types] is added to the constraint system, where $R, \RT, L_1, \ldots, L_K$ are fresh type variables;
-- For each lambda argument with an unknown number of lambda arguments (that is, being equal to 0 or 1), corresponding to the function parameter of type $U_n$, a special constraint of the form [$\left(\FT() \rightarrow R \amp \FT(L) \rightarrow R \amp \FTR(\RT) \rightarrow R \amp \FTR(\RT, L) \rightarrow R\right) <: U_m$][Function types] is added to the constraint system, where $R, \RT, L$ are fresh type variables;
+- For each lambda argument with an unknown number of lambda arguments (that is, being equal to 0 or 1), corresponding to the function parameter of type $U_n$, a special constraint of the form [$\left(\FT() \rightarrow R \amp \FT(L) \rightarrow R \amp \FTR(\RT) \rightarrow R \amp \FTR(\RT, L) \rightarrow R\right) <: U_n$][Function types] is added to the constraint system, where $R, \RT, L$ are fresh type variables;
 
 TODO: in fact, it is an intersection of both non-suspend and suspend variants
 


### PR DESCRIPTION
Every item in the bullet list talks about it's own `U_j`, `U_m`, or `U_n` respectively