### PR TITLE
Drop `;`s from the end of the rules, where they would create derivations, which are not accepted by the kotlin parser

### DIFF
--- a/grammar/src/main/antlr/KotlinParser.g4
+++ b/grammar/src/main/antlr/KotlinParser.g4
@@ -346,7 +346,7 @@ forStatement
     ;
 
 whileStatement
-    : WHILE NL* LPAREN expression RPAREN NL* (controlStructureBody | SEMICOLON)
+    : WHILE NL* LPAREN expression RPAREN NL* controlStructureBody
     ;
 
 doWhileStatement
@@ -614,8 +614,7 @@ superExpression
 ifExpression
     : IF NL* LPAREN NL* expression NL* RPAREN NL*
       ( controlStructureBody
-      | controlStructureBody? NL* SEMICOLON? NL* ELSE NL* (controlStructureBody | SEMICOLON)
-      | SEMICOLON)
+      | controlStructureBody? NL* SEMICOLON? NL* ELSE NL* controlStructureBody)
     ;
 
 whenSubject


### PR DESCRIPTION
The Kotlin compiler parses according to different rules than what are described in this grammar specification. This patch aims to change the grammar to reflect the behaviour of the compiler, as I described in [KT-69130](https://youtrack.jetbrains.com/issue/KT-69130/Syntax-error-Expecting-an-element.-caused-by-semicolon-in-the-if-else-expression), it seems to be a typo in the grammar instead of a bug in the compiler.