### PR TITLE
Fix terminology: Change "first-order functions" to "first-class functions"

### DIFF
--- a/docs/src/md/kotlin.core/type-system.md
+++ b/docs/src/md/kotlin.core/type-system.md
@@ -794,7 +794,7 @@ In case we need to establish type containment between regular type $A$ and captu
 
 #### Function types
 
-Kotlin has first-order functions; e.g., it supports function types, which describe the argument and return types of its corresponding function.
+Kotlin has first-class functions; e.g., it supports function types, which describe the argument and return types of its corresponding function.
 
 A function type $\FT$
 


### PR DESCRIPTION
Hi, maintainers.
Thank you for your daily maintenances.

# Summary

This PR corrects the terminology from "first-order functions" to "first-class functions".

# Changes

- Fix terminology
  - “first-corder function” → “first-class function”

# Motivation

I think “first-class” is correct in this context, not “first-order”.

“first-class” is used elsewhere in [the specification](https://kotlinlang.org/spec/introduction.html#introduction) and [other document](https://kotlinlang.org/docs/lambdas.html).