### PR TITLE
fix: Add VALUE to IdentifierOrSoftKey definition in spec docs

### DIFF
--- a/docs/src/md/kotlin.core/syntax.md
+++ b/docs/src/md/kotlin.core/syntax.md
@@ -495,6 +495,10 @@ Rule names starting with capital letters denote lexical rules, while rule names 
 **_INNER_:**  
   ~ `'inner'`
 :::
+::: { .grammar-rule #grammar-rule-VALUE }
+**_VALUE_:**  
+  ~ `'value'`
+:::
 ::: { .grammar-rule #grammar-rule-TAILREC }
 **_TAILREC_:**  
   ~ `'tailrec'`
@@ -752,6 +756,7 @@ For example, an escaped identifier ``` `foo` ``` and non-escaped identifier `foo
   | [_FILE_](#grammar-rule-FILE)  
   | [_EXPECT_](#grammar-rule-EXPECT)  
   | [_ACTUAL_](#grammar-rule-ACTUAL)  
+  | [_VALUE_](#grammar-rule-VALUE)  
   | [_CONST_](#grammar-rule-CONST)  
   | [_SUSPEND_](#grammar-rule-SUSPEND)
 :::


### PR DESCRIPTION
## Summary

Add the missing `VALUE` soft keyword to both the `IdentifierOrSoftKey` grammar rule and the lexical modifier definitions in `syntax.md`.

## Problem

As reported in #128, the `VALUE` token is present in `KotlinLexer.g4`:
- Line 161: `VALUE: 'value';` (lexical modifier definition)
- Line 302: `| VALUE` (in `IdentifierOrSoftKey` rule)

However, it was missing from the specification documentation in `docs/src/md/kotlin.core/syntax.md`.

## Changes

1. Added `VALUE` keyword definition (`grammar-rule-VALUE`) in the lexical modifiers section, after `INNER`
2. Added `VALUE` to the `IdentifierOrSoftKey` rule, before `CONST` and `SUSPEND`

Both match the ordering in `KotlinLexer.g4`.

Fixes #128